### PR TITLE
feat: 支持群聊卡片发送

### DIFF
--- a/src/dingtalk/bot.ts
+++ b/src/dingtalk/bot.ts
@@ -107,6 +107,15 @@ export class DingTalkBot {
     robotCode?: string,
     conversationType?: string
   ) {
+    logger.info('DingTalk-Bot', '[handleMessage] Start', {
+      conversationId,
+      conversationType,
+      senderNick,
+      senderStaffId,
+      robotCode,
+      sessionWebhookAvailable: !!sessionWebhook,
+    });
+
     logger.info('DingTalk-Bot', '=== New Message Received ===', {
       conversationId,
       senderNick,
@@ -143,13 +152,22 @@ export class DingTalkBot {
       // 创建流式 AI 卡片
       let outTrackId: string | undefined = undefined;
       if (senderStaffId && robotCode) {
-        logger.info('DingTalk-Bot', 'Creating stream card', { conversationId, senderStaffId });
-        const newOutTrackId = await this.dingtalk.createStreamCard(conversationId, robotCode, senderStaffId, text);
+        logger.info('DingTalk-Bot', '[handleMessage] Creating stream card', { conversationId, senderStaffId, conversationType, robotCode });
+        const newOutTrackId = await this.dingtalk.createStreamCard(conversationId, robotCode, senderStaffId, text, conversationType);
         if (newOutTrackId) {
           outTrackId = newOutTrackId;
           conversation.outTrackId = newOutTrackId;
-          logger.info('DingTalk-Bot', 'Stream card created', { conversationId, outTrackId });
+          logger.info('DingTalk-Bot', '[handleMessage] Stream card created', { conversationId, outTrackId });
+        } else {
+          logger.warn('DingTalk-Bot', '[handleMessage] Stream card creation failed', { conversationId, conversationType });
         }
+      } else {
+        logger.warn('DingTalk-Bot', '[handleMessage] Skipping card creation', {
+          conversationId,
+          hasSenderStaffId: !!senderStaffId,
+          hasRobotCode: !!robotCode,
+          conversationType
+        });
       }
 
       // Write context file for MCP tools (e.g. dingtalk_send_image)
@@ -208,7 +226,8 @@ export class DingTalkBot {
           cardPartIndex++;
           const newOutTrackId = await this.dingtalk.createStreamCard(
             conversationId, robotCode, senderStaffId,
-            `(Part ${cardPartIndex + 1})`
+            `(Part ${cardPartIndex + 1})`,
+            conversationType
           );
           if (newOutTrackId) {
             outTrackId = newOutTrackId;

--- a/src/dingtalk/bot.ts
+++ b/src/dingtalk/bot.ts
@@ -107,15 +107,6 @@ export class DingTalkBot {
     robotCode?: string,
     conversationType?: string
   ) {
-    logger.info('DingTalk-Bot', '[handleMessage] Start', {
-      conversationId,
-      conversationType,
-      senderNick,
-      senderStaffId,
-      robotCode,
-      sessionWebhookAvailable: !!sessionWebhook,
-    });
-
     logger.info('DingTalk-Bot', '=== New Message Received ===', {
       conversationId,
       senderNick,
@@ -152,22 +143,13 @@ export class DingTalkBot {
       // 创建流式 AI 卡片
       let outTrackId: string | undefined = undefined;
       if (senderStaffId && robotCode) {
-        logger.info('DingTalk-Bot', '[handleMessage] Creating stream card', { conversationId, senderStaffId, conversationType, robotCode });
+        logger.info('DingTalk-Bot', 'Creating stream card', { conversationId, senderStaffId, conversationType });
         const newOutTrackId = await this.dingtalk.createStreamCard(conversationId, robotCode, senderStaffId, text, conversationType);
         if (newOutTrackId) {
           outTrackId = newOutTrackId;
           conversation.outTrackId = newOutTrackId;
-          logger.info('DingTalk-Bot', '[handleMessage] Stream card created', { conversationId, outTrackId });
-        } else {
-          logger.warn('DingTalk-Bot', '[handleMessage] Stream card creation failed', { conversationId, conversationType });
+          logger.info('DingTalk-Bot', 'Stream card created', { conversationId, outTrackId });
         }
-      } else {
-        logger.warn('DingTalk-Bot', '[handleMessage] Skipping card creation', {
-          conversationId,
-          hasSenderStaffId: !!senderStaffId,
-          hasRobotCode: !!robotCode,
-          conversationType
-        });
       }
 
       // Write context file for MCP tools (e.g. dingtalk_send_image)

--- a/src/dingtalk/client.ts
+++ b/src/dingtalk/client.ts
@@ -193,13 +193,8 @@ export class DingTalkClient {
 
   // 创建流式 AI 卡片
   async createStreamCard(conversationId: string, robotCode: string, senderStaffId: string, query: string = '', conversationType: string = '1'): Promise<string | null> {
-    logger.info('DingTalk-Client', '[createStreamCard] Start', { conversationId, robotCode, senderStaffId, conversationType });
-
     const accessToken = await this.getAccessToken();
-    if (!accessToken) {
-      logger.error('DingTalk-Client', '[createStreamCard] Failed to get access token');
-      return null;
-    }
+    if (!accessToken) return null;
 
     const outTrackId = `claude_${Date.now()}_${Math.random().toString(36).substring(2, 11)}`;
 
@@ -213,7 +208,7 @@ export class DingTalkClient {
       spaceId = `dtv1.card//IM_GROUP.${conversationId}`;
     }
 
-    logger.info('DingTalk-Client', '[createStreamCard] Creating stream card', { outTrackId, spaceId, conversationType });
+    logger.info('DingTalk-Client', 'Creating stream card', { outTrackId, spaceId, conversationType });
 
     try {
       // 根据单聊/群聊构造不同的请求参数
@@ -261,8 +256,6 @@ export class DingTalkClient {
         };
       }
 
-      logger.info('DingTalk-Client', '[createStreamCard] Request payload', { cardData: JSON.stringify(cardData) });
-
       const response = await axios.post(
         'https://api.dingtalk.com/v1.0/card/instances/createAndDeliver',
         cardData,
@@ -274,10 +267,7 @@ export class DingTalkClient {
         }
       );
 
-      logger.info('DingTalk-Client', '[createStreamCard] Response', {
-        status: response.status,
-        data: JSON.stringify(response.data)
-      });
+      logger.info('DingTalk-Client', 'Card created', { result: JSON.stringify(response.data).substring(0, 200) });
 
       this.cardInstances.set(conversationId, { outTrackId, updateSeq: 0 });
 
@@ -294,17 +284,12 @@ export class DingTalkClient {
 
   // 更新 AI 卡片内容 - 使用流式更新接口
   async updateCard(conversationId: string, content: string, isFinal: boolean): Promise<void> {
-    logger.info('DingTalk-Client', '[updateCard] Start', { conversationId, isFinal, contentLength: content.length });
-
     const accessToken = await this.getAccessToken();
-    if (!accessToken) {
-      logger.error('DingTalk-Client', '[updateCard] Failed to get access token');
-      return;
-    }
+    if (!accessToken) return;
 
     const cardInfo = this.cardInstances.get(conversationId);
     if (!cardInfo) {
-      logger.warn('DingTalk-Client', '[updateCard] No card instance found', { conversationId });
+      logger.warn('DingTalk-Client', 'No card instance found for conversation', { conversationId });
       return;
     }
 
@@ -313,7 +298,7 @@ export class DingTalkClient {
     const guid = `${cardInfo.outTrackId}_${cardInfo.updateSeq}`;
     const { outTrackId } = cardInfo;
 
-    logger.info('DingTalk-Client', '[updateCard] Streaming card update', {
+    logger.info('DingTalk-Client', 'Streaming card update', {
       outTrackId,
       guid,
       seq: cardInfo.updateSeq,

--- a/src/dingtalk/client.ts
+++ b/src/dingtalk/client.ts
@@ -192,32 +192,45 @@ export class DingTalkClient {
   }
 
   // 创建流式 AI 卡片
-  async createStreamCard(conversationId: string, robotCode: string, senderStaffId: string, query: string = ''): Promise<string | null> {
+  async createStreamCard(conversationId: string, robotCode: string, senderStaffId: string, query: string = '', conversationType: string = '1'): Promise<string | null> {
+    logger.info('DingTalk-Client', '[createStreamCard] Start', { conversationId, robotCode, senderStaffId, conversationType });
+
     const accessToken = await this.getAccessToken();
-    if (!accessToken) return null;
+    if (!accessToken) {
+      logger.error('DingTalk-Client', '[createStreamCard] Failed to get access token');
+      return null;
+    }
 
     const outTrackId = `claude_${Date.now()}_${Math.random().toString(36).substring(2, 11)}`;
-    const spaceId = `dtv1.card//im_robot.${senderStaffId}`;
 
-    logger.info('DingTalk-Client', 'Creating stream card', { outTrackId, spaceId });
+    // 根据会话类型设置不同的 openSpaceId
+    let spaceId: string;
+    if (conversationType === '1') {
+      // 单聊
+      spaceId = `dtv1.card//IM_ROBOT.${senderStaffId}`;
+    } else {
+      // 群聊
+      spaceId = `dtv1.card//IM_GROUP.${conversationId}`;
+    }
+
+    logger.info('DingTalk-Client', '[createStreamCard] Creating stream card', { outTrackId, spaceId, conversationType });
 
     try {
-      const response = await axios.post(
-        'https://api.dingtalk.com/v1.0/card/instances/createAndDeliver',
-        {
-          userId: senderStaffId,
-          userIdType: 1,
+      // 根据单聊/群聊构造不同的请求参数
+      let cardData: any;
+
+      if (conversationType === '1') {
+        // 单聊参数（参考官网示例）
+        cardData = {
           cardTemplateId: CARD_TEMPLATE_ID,
           outTrackId: outTrackId,
           callbackType: 'STREAM',
           openSpaceId: spaceId,
-          robotCode: robotCode,
-          imRobotOpenDeliverModel: {
-            spaceType: 'IM_ROBOT',
-            robotCode: robotCode
-          },
           imRobotOpenSpaceModel: {
             supportForward: true
+          },
+          imRobotOpenDeliverModel: {
+            spaceType: 'IM_ROBOT'
           },
           cardData: {
             cardParamMap: {
@@ -225,7 +238,34 @@ export class DingTalkClient {
               flowStatus: '2',
             }
           }
-        },
+        };
+      } else {
+        // 群聊参数（参考官网示例）
+        cardData = {
+          cardTemplateId: CARD_TEMPLATE_ID,
+          outTrackId: outTrackId,
+          callbackType: 'STREAM',
+          openSpaceId: spaceId,
+          imGroupOpenSpaceModel: {
+            supportForward: true
+          },
+          imGroupOpenDeliverModel: {
+            robotCode: robotCode
+          },
+          cardData: {
+            cardParamMap: {
+              content: '# 正在思考...',
+              flowStatus: '2',
+            }
+          }
+        };
+      }
+
+      logger.info('DingTalk-Client', '[createStreamCard] Request payload', { cardData: JSON.stringify(cardData) });
+
+      const response = await axios.post(
+        'https://api.dingtalk.com/v1.0/card/instances/createAndDeliver',
+        cardData,
         {
           headers: {
             'x-acs-dingtalk-access-token': accessToken,
@@ -234,7 +274,10 @@ export class DingTalkClient {
         }
       );
 
-      logger.info('DingTalk-Client', 'Card created', { result: JSON.stringify(response.data).substring(0, 200) });
+      logger.info('DingTalk-Client', '[createStreamCard] Response', {
+        status: response.status,
+        data: JSON.stringify(response.data)
+      });
 
       this.cardInstances.set(conversationId, { outTrackId, updateSeq: 0 });
 
@@ -251,12 +294,17 @@ export class DingTalkClient {
 
   // 更新 AI 卡片内容 - 使用流式更新接口
   async updateCard(conversationId: string, content: string, isFinal: boolean): Promise<void> {
+    logger.info('DingTalk-Client', '[updateCard] Start', { conversationId, isFinal, contentLength: content.length });
+
     const accessToken = await this.getAccessToken();
-    if (!accessToken) return;
+    if (!accessToken) {
+      logger.error('DingTalk-Client', '[updateCard] Failed to get access token');
+      return;
+    }
 
     const cardInfo = this.cardInstances.get(conversationId);
     if (!cardInfo) {
-      logger.warn('DingTalk-Client', 'No card instance found for conversation', { conversationId });
+      logger.warn('DingTalk-Client', '[updateCard] No card instance found', { conversationId });
       return;
     }
 
@@ -265,7 +313,7 @@ export class DingTalkClient {
     const guid = `${cardInfo.outTrackId}_${cardInfo.updateSeq}`;
     const { outTrackId } = cardInfo;
 
-    logger.info('DingTalk-Client', 'Streaming card update', {
+    logger.info('DingTalk-Client', '[updateCard] Streaming card update', {
       outTrackId,
       guid,
       seq: cardInfo.updateSeq,


### PR DESCRIPTION
## 变更内容

- 修改 `createStreamCard` 方法，根据 `conversationType` 区分单聊/群聊参数
- 单聊使用 `imRobotOpenSpaceModel` 和 `imRobotOpenDeliverModel`
- 群聊使用 `imGroupOpenSpaceModel` 和 `imGroupOpenDeliverModel`
- 群聊 `openSpaceId` 使用 `IM_GROUP.{conversationId}` 格式

## 修复问题

修复了群聊消息无法发送卡片的问题，钉钉 API 返回 `deliverResults: []` 导致卡片未投递到群组。

## 测试

已在群聊环境测试通过，卡片可正常发送和更新。